### PR TITLE
Fixing color contrast for quick suggest pop-ups

### DIFF
--- a/themes/nako-dark-color-theme.json
+++ b/themes/nako-dark-color-theme.json
@@ -7,6 +7,7 @@
     "button.background": "#60A7FA",
     "button.foreground": "#000",
     "quickInput.background": "#131A20",
+    "quickInputList.focusBackground": "#fff",
 
     /* Editor */
     "editor.background": "#1B2227",
@@ -19,6 +20,7 @@
     "editor.lineHighlightBorder": "#242D34",
     "editor.lineHighlightBackground": "#242D34",
     "editorCursor.foreground": "#79ffe1",
+    "editorSuggestWidget.focusHighlightForeground": "#ff0078",
 
     /* Sidebar */
     "sideBar.background": "#131A20",

--- a/themes/nako-light-color-theme.json
+++ b/themes/nako-light-color-theme.json
@@ -7,6 +7,7 @@
     "button.background": "#60A7FA",
     "button.foreground": "#000",
     "quickInput.background": "#EAEAEA",
+    "quickInputList.focusBackground": "#ff0078",
 
     /* Editor */
     "editor.background": "#fefefe",
@@ -19,7 +20,8 @@
     "editor.lineHighlightBorder": "#f7f7f7",
     "editor.lineHighlightBackground": "#f7f7f7",
     "editorCursor.foreground": "#79ffe1",
-
+    "editorSuggestWidget.focusHighlightForeground": "#fff",
+    
     /* Sidebar */
     "sideBar.background": "#fefefe",
     "sideBar.border": "#EAEAEA",


### PR DESCRIPTION
this is a great theme , thanks for this !! 

I found a small issue with the editor suggest and the quickinput pop-up though. I see a [ #similar issue](https://github.com/kettanaito/vscode-nako-theme/issues/7),  been raised here. 

I'm not sure about the thought process for color selection. I fixed the contrast problem alone, with the color of my liking. Happy to correct this

Screenshots post this fix:

**DarkTheme**

<img width="1113" alt="DarkTheme" src="https://user-images.githubusercontent.com/380340/179712356-53e4a84e-2ba9-4bda-8fdd-9c81d82a89d1.png">

**LightTheme**

<img width="1129" alt="LightTheme" src="https://user-images.githubusercontent.com/380340/179712379-e45c622d-9bc7-4bec-9e88-faa13e65efbd.png">
